### PR TITLE
Enable custom routes scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ model/
 
 ---
 
+## ➕ Custom Routes
+
+You can define additional routes per model by creating a `custom-routes.json` file in your project root.
+
+Example:
+
+```json
+{
+  "User": [
+    { "name": "disable", "method": "post", "path": "/:id/disable", "description": "Disable a user" }
+  ]
+}
+```
+
+This will generate:
+
+* A new controller.disable method
+
+* A route in router.post('/:id/disable', controller.disable);
+
+---
+
 ## 📜 License
 
 MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-api-gen",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-api-gen",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@prisma/generator-helper": "^6.5.0",
         "yargs": "^17.7.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-api-gen",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-api-gen",
-      "version": "1.1.3",
+      "version": "1.2.0",
       "dependencies": {
         "@prisma/generator-helper": "^6.5.0",
         "yargs": "^17.7.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-api-gen",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "license": "MIT",
   "author": "Nimisoere Tekena-Lawson",
   "description": "Generate grouped modules, routes, tests, and OpenAPI docs from your Prisma schema",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-api-gen",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "MIT",
   "author": "Nimisoere Tekena-Lawson",
   "description": "Generate grouped modules, routes, tests, and OpenAPI docs from your Prisma schema",


### PR DESCRIPTION
Enable custom routes scaffolding. 

## ➕ Custom Routes

You can define additional routes per model by creating a `custom-routes.json` file in your project root.

Example:

```json
{
  "User": [
    { "name": "disable", "method": "post", "path": "/:id/disable", "description": "Disable a user" }
  ]
}
```

This will generate:

* A new controller.disable method

* A route in router.post('/:id/disable', controller.disable);